### PR TITLE
feat: add training metrics reporting

### DIFF
--- a/modules/core/src/main/scala/tekhne/model.scala
+++ b/modules/core/src/main/scala/tekhne/model.scala
@@ -95,6 +95,12 @@ final case class TrainingConfig(
   require(epochs > 0, s"epochs must be positive, got $epochs")
   require(batchSize > 0, s"batch size must be positive, got $batchSize")
 
+/** Loss snapshot reported after an epoch completes. */
+final case class EpochMetrics(
+    epoch: Int,
+    loss: Double
+)
+
 private[tekhne] final case class LayerCache(
     input: Vec,
     preActivation: Vec,

--- a/modules/core/src/main/scala/tekhne/training.scala
+++ b/modules/core/src/main/scala/tekhne/training.scala
@@ -6,6 +6,8 @@ import scala.util.Random
 
 /** Training helpers built around plain stochastic gradient descent. */
 object Training:
+  private def noOpMetricsHandler(metrics: EpochMetrics): Unit = ()
+
   private def batchData(
       data: Vector[(Vec, Vec)],
       batchSize: Int
@@ -50,13 +52,14 @@ object Training:
   private def trainDeterministic(
       network: Network,
       data: Vector[(Vec, Vec)],
-      config: TrainingConfig
-  ): Network =
-    Iterator
-      .fill(config.epochs)(())
-      .foldLeft(network) { case (current, _) =>
-        trainEpoch(current, data, config.learningRate, config.batchSize, config.loss)
-      }
+      config: TrainingConfig,
+      onEpochComplete: EpochMetrics => Unit = noOpMetricsHandler
+  ): Network = (1 to config.epochs)
+    .foldLeft(network) { case (current, epoch) =>
+      val updated = trainEpoch(current, data, config.learningRate, config.batchSize, config.loss)
+      onEpochComplete(EpochMetrics(epoch, datasetLoss(updated, data, config.loss)))
+      updated
+    }
 
   /** Applies one stochastic gradient descent update for a single training example. */
   def step(
@@ -109,6 +112,19 @@ object Training:
     require(data.nonEmpty, "training data must be non-empty")
     trainDeterministic(network, data, config)
 
+  def train(
+      network: Network,
+      data: Vector[(Vec, Vec)],
+      config: TrainingConfig,
+      onEpochComplete: EpochMetrics => Unit
+  ): Network =
+    require(
+      !config.shuffleEachEpoch,
+      "shuffleEachEpoch = true requires the Training.train overload that accepts a Random"
+    )
+    require(data.nonEmpty, "training data must be non-empty")
+    trainDeterministic(network, data, config, onEpochComplete)
+
   /** Trains for the configured number of epochs.
     *
     * When `shuffleEachEpoch` is enabled, `rng` controls the per-epoch dataset shuffling.
@@ -119,15 +135,26 @@ object Training:
       config: TrainingConfig,
       rng: Random
   ): Network =
+    train(network, data, config, rng, noOpMetricsHandler)
+
+  def train(
+      network: Network,
+      data: Vector[(Vec, Vec)],
+      config: TrainingConfig,
+      rng: Random,
+      onEpochComplete: EpochMetrics => Unit
+  ): Network =
     require(data.nonEmpty, "training data must be non-empty")
 
-    Iterator
-      .fill(config.epochs)(())
-      .foldLeft(network) { case (current, _) =>
+    (1 to config.epochs)
+      .foldLeft(network) { case (current, epoch) =>
         val epochData =
           if config.shuffleEachEpoch then rng.shuffle(data)
           else data
-        trainEpoch(current, epochData, config.learningRate, config.batchSize, config.loss)
+        val updated   =
+          trainEpoch(current, epochData, config.learningRate, config.batchSize, config.loss)
+        onEpochComplete(EpochMetrics(epoch, datasetLoss(updated, data, config.loss)))
+        updated
       }
 
   /** Computes the average dataset loss with the current network parameters. */

--- a/modules/core/src/test/scala/tekhne/TrainingSuite.scala
+++ b/modules/core/src/test/scala/tekhne/TrainingSuite.scala
@@ -2,6 +2,8 @@ package tekhne
 
 import scala.util.Random
 
+import scala.collection.mutable.ArrayBuffer
+
 class TrainingSuite extends munit.FunSuite:
   private val xorData = Vector(
     (Vector(0.0, 0.0), Vector(0.0)),
@@ -283,4 +285,69 @@ class TrainingSuite extends munit.FunSuite:
     assert(predictions(1) > 0.9)
     assert(predictions(2) > 0.9)
     assert(predictions(3) < 0.1)
+  }
+
+  test("training callback is invoked once per epoch with increasing epoch numbers") {
+    val network = Network.random(
+      layerSizes = Vector(2, 3, 1),
+      activations = Vector(Activation.Tanh, Activation.Sigmoid),
+      rng = new Random(42L)
+    )
+
+    val config = TrainingConfig(
+      learningRate = 0.1,
+      epochs = 4,
+      batchSize = 2
+    )
+
+    val observed = ArrayBuffer.empty[EpochMetrics]
+
+    Training.train(network, xorData, config, metrics => observed += metrics)
+
+    assertEquals(observed.map(_.epoch).toVector, Vector(1, 2, 3, 4))
+    assert(observed.forall(metrics => metrics.loss.isFinite))
+  }
+
+  test("reported losses decrease during BCE training") {
+    val network = Network.random(
+      layerSizes = Vector(2, 3, 1),
+      activations = Vector(Activation.Tanh, Activation.Sigmoid),
+      rng = new Random(42L)
+    )
+
+    val config = TrainingConfig(
+      learningRate = 0.1,
+      epochs = 10,
+      batchSize = 2,
+      loss = LossFunction.BinaryCrossEntropy
+    )
+
+    val observed = ArrayBuffer.empty[EpochMetrics]
+
+    Training.train(network, xorData, config, metrics => observed += metrics)
+
+    assertEquals(observed.length, 10)
+    assert(observed.last.loss < observed.head.loss)
+  }
+
+  test("metrics callback works with shuffled training when rng is provided") {
+    val network = Network.random(
+      layerSizes = Vector(2, 3, 1),
+      activations = Vector(Activation.Tanh, Activation.Sigmoid),
+      rng = new Random(42L)
+    )
+
+    val config = TrainingConfig(
+      learningRate = 0.1,
+      epochs = 5,
+      shuffleEachEpoch = true,
+      batchSize = 2
+    )
+
+    val observed = ArrayBuffer.empty[EpochMetrics]
+
+    Training.train(network, xorData, config, new Random(42L), metrics => observed += metrics)
+
+    assertEquals(observed.map(_.epoch).toVector, Vector(1, 2, 3, 4, 5))
+    assert(observed.forall(metrics => metrics.loss.isFinite))
   }

--- a/modules/core/src/test/scala/tekhne/TrainingSuite.scala
+++ b/modules/core/src/test/scala/tekhne/TrainingSuite.scala
@@ -1,8 +1,7 @@
 package tekhne
 
-import scala.util.Random
-
 import scala.collection.mutable.ArrayBuffer
+import scala.util.Random
 
 class TrainingSuite extends munit.FunSuite:
   private val xorData = Vector(


### PR DESCRIPTION
## Summary
- add callback-based epoch metrics reporting to training
- keep the current default training API unchanged and quiet
- add tests for callback behavior and reported loss trends

## Why
- make training progress easier to observe in demos and experiments
- keep metrics reporting lightweight and library-friendly

## Related
- Closes #29
- Related to #35

## Verification
- [x] `sbt test`
- [x] `sbt scalafmtAll`
- [ ] relevant manual check, if needed

## Out of scope / follow-ups
- richer metrics beyond epoch loss
- training API overload simplification