### PR TITLE
feat: add linearly separable demo dataset

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ A tiny neural network in idiomatic Scala 3.
 - dense feed-forward layers
 - forward pass and backpropagation
 - stochastic gradient descent training
-- XOR and AND demo programs
+- XOR, AND, and linearly separable demo programs
 
 ## Non-goals
 
@@ -77,6 +77,7 @@ sbt compile
 sbt test
 sbt "demo/runMain tekhne.demo.runTekhne"
 sbt "demo/runMain tekhne.demo.runAndGateDemo"
+sbt "demo/runMain tekhne.demo.runLinearlySeparableDemo"
 sbt core/test
 sbt scalafmtAll
 sbt scalafixAll
@@ -85,6 +86,7 @@ sbt "project core" clean coverage test coverageReport
 
 ## Roadmap
 
-- binary cross-entropy loss
+- another small demo dataset
+- define the 0.1.0 milestone
+- validate loss and output activation compatibility
 - additional losses and optimizers
-- training metrics and reporting

--- a/modules/core/src/test/scala/tekhne/TrainingSuite.scala
+++ b/modules/core/src/test/scala/tekhne/TrainingSuite.scala
@@ -11,6 +11,17 @@ class TrainingSuite extends munit.FunSuite:
     (Vector(1.0, 1.0), Vector(0.0))
   )
 
+  private val linearlySeparableData = Vector(
+    (Vector(0.0, 0.1), Vector(0.0)),
+    (Vector(0.1, 0.2), Vector(0.0)),
+    (Vector(0.2, 0.1), Vector(0.0)),
+    (Vector(0.3, 0.2), Vector(0.0)),
+    (Vector(0.7, 0.8), Vector(1.0)),
+    (Vector(0.8, 0.9), Vector(1.0)),
+    (Vector(0.9, 0.8), Vector(1.0)),
+    (Vector(0.8, 0.7), Vector(1.0))
+  )
+
   test("training lowers xor loss") {
     val network = Network.random(
       layerSizes = Vector(2, 3, 1),
@@ -349,4 +360,32 @@ class TrainingSuite extends munit.FunSuite:
 
     assertEquals(observed.map(_.epoch).toVector, Vector(1, 2, 3, 4, 5))
     assert(observed.forall(metrics => metrics.loss.isFinite))
+  }
+
+  test("linearly separable dataset learns successfully") {
+    val network = Network.random(
+      layerSizes = Vector(2, 1),
+      activations = Vector(Activation.Sigmoid),
+      rng = new Random(42L)
+    )
+
+    val config = TrainingConfig(
+      learningRate = 0.1,
+      epochs = 5_000,
+      shuffleEachEpoch = true,
+      batchSize = 2,
+      loss = LossFunction.BinaryCrossEntropy
+    )
+
+    val initialLoss = Training.datasetLoss(network, linearlySeparableData, config.loss)
+    val trained     = Training.train(network, linearlySeparableData, config, new Random(42L))
+    val finalLoss   = Training.datasetLoss(trained, linearlySeparableData, config.loss)
+    val predictions = linearlySeparableData.map { case (input, _) =>
+      Forward.predict(trained, input).head
+    }
+
+    assert(finalLoss < initialLoss)
+    assert(finalLoss < 0.02)
+    assert(predictions.take(4).forall(_ < 0.1))
+    assert(predictions.drop(4).forall(_ > 0.9))
   }

--- a/modules/demo/src/main/scala/LinearlySeparableDemo.scala
+++ b/modules/demo/src/main/scala/LinearlySeparableDemo.scala
@@ -1,6 +1,6 @@
 package tekhne.demo
 
-import tekhne.*
+import tekhne._
 
 import scala.util.Random
 

--- a/modules/demo/src/main/scala/LinearlySeparableDemo.scala
+++ b/modules/demo/src/main/scala/LinearlySeparableDemo.scala
@@ -1,0 +1,53 @@
+package tekhne.demo
+
+import tekhne.*
+
+import scala.util.Random
+
+@main def runLinearlySeparableDemo(): Unit =
+  val data = Vector(
+    (Vector(0.0, 0.1), Vector(0.0)),
+    (Vector(0.1, 0.2), Vector(0.0)),
+    (Vector(0.2, 0.1), Vector(0.0)),
+    (Vector(0.3, 0.2), Vector(0.0)),
+    (Vector(0.7, 0.8), Vector(1.0)),
+    (Vector(0.8, 0.9), Vector(1.0)),
+    (Vector(0.9, 0.8), Vector(1.0)),
+    (Vector(0.8, 0.7), Vector(1.0))
+  )
+
+  val network = Network.random(
+    layerSizes = Vector(2, 1),
+    activations = Vector(Activation.Sigmoid),
+    rng = new Random(42L)
+  )
+
+  val config = TrainingConfig(
+    learningRate = 0.1,
+    epochs = 5_000,
+    shuffleEachEpoch = true,
+    batchSize = 2,
+    loss = LossFunction.BinaryCrossEntropy
+  )
+
+  val initialLoss = Training.datasetLoss(network, data, config.loss)
+  println("Linearly separable demo")
+  println(f"initial loss: $initialLoss%.6f")
+
+  val trained = Training.train(
+    network,
+    data,
+    config,
+    new Random(42L),
+    metrics =>
+      if metrics.epoch % 500 == 0 then
+        println(f"epoch ${metrics.epoch}%4d loss=${metrics.loss}%.6f")
+  )
+
+  val finalLoss = Training.datasetLoss(trained, data, config.loss)
+  println(f"final loss:   $finalLoss%.6f")
+
+  data.foreach { case (input, target) =>
+    val prediction = Forward.predict(trained, input)
+    println(s"input=$input target=$target prediction=$prediction")
+  }


### PR DESCRIPTION
## Summary
- add a small linearly separable classification demo alongside XOR and AND
- add a focused training test for the new dataset
- update the README scope, commands, and roadmap to reflect the current project state

## Why
- add a simple classification example that contrasts with XOR
- showcase the current training stack with BCE, mini-batching, and metrics

## Related
- Closes #26

## Verification
- [x] `sbt test`
- [x] `sbt scalafmtAll`
- [x] `sbt "demo/runMain tekhne.demo.runLinearlySeparableDemo"`

## Out of scope / follow-ups
- more complex synthetic datasets
- plotting or visualization support