### PR TITLE
fix: validate loss and output compatibility

### DIFF
--- a/modules/core/src/main/scala/tekhne/training.scala
+++ b/modules/core/src/main/scala/tekhne/training.scala
@@ -8,6 +8,15 @@ import scala.util.Random
 object Training:
   private def noOpMetricsHandler(metrics: EpochMetrics): Unit = ()
 
+  private def requireLossCompatibility(network: Network, loss: LossFunction): Unit =
+    loss match
+      case LossFunction.MeanSquaredError   => ()
+      case LossFunction.BinaryCrossEntropy =>
+        require(
+          network.layers.last.activation == Activation.Sigmoid,
+          "binary cross-entropy requires a sigmoid output layer"
+        )
+
   private def batchData(
       data: Vector[(Vec, Vec)],
       batchSize: Int
@@ -70,6 +79,7 @@ object Training:
       loss: LossFunction = LossFunction.MeanSquaredError
   ): Network =
     require(learningRate > 0.0, s"learning rate must be positive, got $learningRate")
+    requireLossCompatibility(network, loss)
 
     val grads = Backprop.gradients(network, input, target, loss)
 
@@ -92,6 +102,7 @@ object Training:
       loss: LossFunction = LossFunction.MeanSquaredError
   ): Network =
     require(batchSize > 0, s"batch size must be positive, got $batchSize")
+    requireLossCompatibility(network, loss)
     batchData(data, batchSize).foldLeft(network) { case (current, batch) =>
       stepBatch(current, batch, learningRate, loss)
     }
@@ -110,6 +121,7 @@ object Training:
       "shuffleEachEpoch = true requires the Training.train overload that accepts a Random"
     )
     require(data.nonEmpty, "training data must be non-empty")
+    requireLossCompatibility(network, config.loss)
     trainDeterministic(network, data, config)
 
   def train(
@@ -123,6 +135,7 @@ object Training:
       "shuffleEachEpoch = true requires the Training.train overload that accepts a Random"
     )
     require(data.nonEmpty, "training data must be non-empty")
+    requireLossCompatibility(network, config.loss)
     trainDeterministic(network, data, config, onEpochComplete)
 
   /** Trains for the configured number of epochs.
@@ -145,6 +158,7 @@ object Training:
       onEpochComplete: EpochMetrics => Unit
   ): Network =
     require(data.nonEmpty, "training data must be non-empty")
+    requireLossCompatibility(network, config.loss)
 
     (1 to config.epochs)
       .foldLeft(network) { case (current, epoch) =>
@@ -164,6 +178,7 @@ object Training:
       loss: LossFunction = LossFunction.MeanSquaredError
   ): Double =
     require(data.nonEmpty, "training data must be non-empty")
+    requireLossCompatibility(network, loss)
     data.map { case (input, target) =>
       Loss.value(loss, Forward.predict(network, input), target)
     }.sum /

--- a/modules/core/src/test/scala/tekhne/ValidationSuite.scala
+++ b/modules/core/src/test/scala/tekhne/ValidationSuite.scala
@@ -60,3 +60,49 @@ class ValidationSuite extends munit.FunSuite:
       TrainingConfig(learningRate = 0.1, epochs = 10, batchSize = 0)
     }
   }
+
+  test("binary cross-entropy requires sigmoid output for training") {
+    val network = Network(
+      Vector(
+        Dense(
+          weights = Vector(Vector(0.1, 0.2)),
+          bias = Vector(0.0),
+          activation = Activation.Identity
+        )
+      )
+    )
+
+    val config = TrainingConfig(
+      learningRate = 0.1,
+      epochs = 10,
+      loss = LossFunction.BinaryCrossEntropy
+    )
+
+    interceptMessage[IllegalArgumentException](
+      "requirement failed: binary cross-entropy requires a sigmoid output layer"
+    ) {
+      Training.train(network, Vector((Vector(0.0, 1.0), Vector(1.0))), config)
+    }
+  }
+
+  test("binary cross-entropy requires sigmoid output for dataset loss") {
+    val network = Network(
+      Vector(
+        Dense(
+          weights = Vector(Vector(0.1, 0.2)),
+          bias = Vector(0.0),
+          activation = Activation.Identity
+        )
+      )
+    )
+
+    interceptMessage[IllegalArgumentException](
+      "requirement failed: binary cross-entropy requires a sigmoid output layer"
+    ) {
+      Training.datasetLoss(
+        network,
+        Vector((Vector(0.0, 1.0), Vector(1.0))),
+        LossFunction.BinaryCrossEntropy
+      )
+    }
+  }


### PR DESCRIPTION
## Summary
- add a lightweight compatibility check between the selected loss and the final layer activation
- reject binary cross-entropy unless the output layer uses `Sigmoid`
- add validation tests for training and dataset loss paths

## Why
- make the current BCE behavior more explicit and safer to use
- protect the public API from a known misuse case without adding much complexity

## Related
- Closes #34

## Verification
- [x] `sbt test`
- [x] `sbt scalafmtAll`
- [ ] relevant manual check, if needed

## Out of scope / follow-ups
- broader activation/loss compatibility rules
- moving compatibility checks into a separate module