### PR TITLE
refactor: simplify training API overloads

### DIFF
--- a/modules/core/src/main/scala/tekhne/training.scala
+++ b/modules/core/src/main/scala/tekhne/training.scala
@@ -8,6 +8,11 @@ import scala.util.Random
 object Training:
   private def noOpMetricsHandler(metrics: EpochMetrics): Unit = ()
 
+  private final case class TrainingRuntime(
+      rng: Option[Random],
+      onEpochComplete: EpochMetrics => Unit
+  )
+
   private def requireLossCompatibility(network: Network, loss: LossFunction): Unit =
     loss match
       case LossFunction.MeanSquaredError   => ()
@@ -58,17 +63,30 @@ object Training:
 
     Network(updatedLayers)
 
-  private def trainDeterministic(
+  private def trainWithRuntime(
       network: Network,
       data: Vector[(Vec, Vec)],
       config: TrainingConfig,
-      onEpochComplete: EpochMetrics => Unit = noOpMetricsHandler
-  ): Network = (1 to config.epochs)
-    .foldLeft(network) { case (current, epoch) =>
-      val updated = trainEpoch(current, data, config.learningRate, config.batchSize, config.loss)
-      onEpochComplete(EpochMetrics(epoch, datasetLoss(updated, data, config.loss)))
-      updated
-    }
+      runtime: TrainingRuntime
+  ): Network =
+    require(data.nonEmpty, "training data must be non-empty")
+    requireLossCompatibility(network, config.loss)
+    require(
+      !config.shuffleEachEpoch || runtime.rng.nonEmpty,
+      "shuffleEachEpoch = true requires the fully explicit Training.train overload"
+    )
+
+    (1 to config.epochs)
+      .foldLeft(network) { case (current, epoch) =>
+        val epochData = runtime.rng match
+          case Some(rng) if config.shuffleEachEpoch => rng.shuffle(data)
+          case _                                    => data
+
+        val updated =
+          trainEpoch(current, epochData, config.learningRate, config.batchSize, config.loss)
+        runtime.onEpochComplete(EpochMetrics(epoch, datasetLoss(updated, data, config.loss)))
+        updated
+      }
 
   /** Applies one stochastic gradient descent update for a single training example. */
   def step(
@@ -109,47 +127,20 @@ object Training:
 
   /** Trains without shuffling.
     *
-    * If `shuffleEachEpoch` is enabled, use the overload that accepts a `Random`.
+    * If `shuffleEachEpoch` is enabled, use the fully explicit overload.
     */
   def train(
       network: Network,
       data: Vector[(Vec, Vec)],
       config: TrainingConfig
   ): Network =
-    require(
-      !config.shuffleEachEpoch,
-      "shuffleEachEpoch = true requires the Training.train overload that accepts a Random"
-    )
-    require(data.nonEmpty, "training data must be non-empty")
-    requireLossCompatibility(network, config.loss)
-    trainDeterministic(network, data, config)
-
-  def train(
-      network: Network,
-      data: Vector[(Vec, Vec)],
-      config: TrainingConfig,
-      onEpochComplete: EpochMetrics => Unit
-  ): Network =
-    require(
-      !config.shuffleEachEpoch,
-      "shuffleEachEpoch = true requires the Training.train overload that accepts a Random"
-    )
-    require(data.nonEmpty, "training data must be non-empty")
-    requireLossCompatibility(network, config.loss)
-    trainDeterministic(network, data, config, onEpochComplete)
+    trainWithRuntime(network, data, config, TrainingRuntime(None, noOpMetricsHandler))
 
   /** Trains for the configured number of epochs.
     *
-    * When `shuffleEachEpoch` is enabled, `rng` controls the per-epoch dataset shuffling.
+    * `rng` controls per-epoch dataset shuffling when enabled and `onEpochComplete` receives loss
+    * snapshots after each epoch.
     */
-  def train(
-      network: Network,
-      data: Vector[(Vec, Vec)],
-      config: TrainingConfig,
-      rng: Random
-  ): Network =
-    train(network, data, config, rng, noOpMetricsHandler)
-
   def train(
       network: Network,
       data: Vector[(Vec, Vec)],
@@ -157,19 +148,7 @@ object Training:
       rng: Random,
       onEpochComplete: EpochMetrics => Unit
   ): Network =
-    require(data.nonEmpty, "training data must be non-empty")
-    requireLossCompatibility(network, config.loss)
-
-    (1 to config.epochs)
-      .foldLeft(network) { case (current, epoch) =>
-        val epochData =
-          if config.shuffleEachEpoch then rng.shuffle(data)
-          else data
-        val updated   =
-          trainEpoch(current, epochData, config.learningRate, config.batchSize, config.loss)
-        onEpochComplete(EpochMetrics(epoch, datasetLoss(updated, data, config.loss)))
-        updated
-      }
+    trainWithRuntime(network, data, config, TrainingRuntime(Some(rng), onEpochComplete))
 
   /** Computes the average dataset loss with the current network parameters. */
   def datasetLoss(

--- a/modules/core/src/test/scala/tekhne/TrainingSuite.scala
+++ b/modules/core/src/test/scala/tekhne/TrainingSuite.scala
@@ -89,7 +89,8 @@ class TrainingSuite extends munit.FunSuite:
         epochs = 50_000,
         shuffleEachEpoch = true
       ),
-      new Random(42L)
+      new Random(42L),
+      _ => ()
     )
 
     val finalLoss = Training.datasetLoss(trained, xorData)
@@ -111,8 +112,8 @@ class TrainingSuite extends munit.FunSuite:
       shuffleEachEpoch = true
     )
 
-    val trained1 = Training.train(network, xorData, config, new Random(42L))
-    val trained2 = Training.train(network, xorData, config, new Random(42L))
+    val trained1 = Training.train(network, xorData, config, new Random(42L), _ => ())
+    val trained2 = Training.train(network, xorData, config, new Random(42L), _ => ())
 
     assertEquals(trained1, trained2)
   }
@@ -131,7 +132,7 @@ class TrainingSuite extends munit.FunSuite:
     )
 
     interceptMessage[IllegalArgumentException](
-      "requirement failed: shuffleEachEpoch = true requires the Training.train overload that accepts a Random"
+      "requirement failed: shuffleEachEpoch = true requires the fully explicit Training.train overload"
     ) {
       Training.train(network, xorData, config)
     }
@@ -150,8 +151,8 @@ class TrainingSuite extends munit.FunSuite:
       shuffleEachEpoch = true
     )
 
-    val trained1 = Training.train(network, xorData, config, new Random(42L))
-    val trained2 = Training.train(network, xorData, config, new Random(7L))
+    val trained1 = Training.train(network, xorData, config, new Random(42L), _ => ())
+    val trained2 = Training.train(network, xorData, config, new Random(7L), _ => ())
 
     assertNotEquals(trained1, trained2)
   }
@@ -241,8 +242,8 @@ class TrainingSuite extends munit.FunSuite:
       batchSize = 2
     )
 
-    val trained1 = Training.train(network, xorData, config, new Random(42L))
-    val trained2 = Training.train(network, xorData, config, new Random(42L))
+    val trained1 = Training.train(network, xorData, config, new Random(42L), _ => ())
+    val trained2 = Training.train(network, xorData, config, new Random(42L), _ => ())
 
     assertEquals(trained1, trained2)
   }
@@ -312,7 +313,7 @@ class TrainingSuite extends munit.FunSuite:
 
     val observed = ArrayBuffer.empty[EpochMetrics]
 
-    Training.train(network, xorData, config, metrics => observed += metrics)
+    Training.train(network, xorData, config, new Random(0L), metrics => observed += metrics)
 
     assertEquals(observed.map(_.epoch).toVector, Vector(1, 2, 3, 4))
     assert(observed.forall(metrics => metrics.loss.isFinite))
@@ -334,7 +335,7 @@ class TrainingSuite extends munit.FunSuite:
 
     val observed = ArrayBuffer.empty[EpochMetrics]
 
-    Training.train(network, xorData, config, metrics => observed += metrics)
+    Training.train(network, xorData, config, new Random(0L), metrics => observed += metrics)
 
     assertEquals(observed.length, 10)
     assert(observed.last.loss < observed.head.loss)
@@ -378,7 +379,7 @@ class TrainingSuite extends munit.FunSuite:
     )
 
     val initialLoss = Training.datasetLoss(network, linearlySeparableData, config.loss)
-    val trained     = Training.train(network, linearlySeparableData, config, new Random(42L))
+    val trained     = Training.train(network, linearlySeparableData, config, new Random(42L), _ => ())
     val finalLoss   = Training.datasetLoss(trained, linearlySeparableData, config.loss)
     val predictions = linearlySeparableData.map { case (input, _) =>
       Forward.predict(trained, input).head


### PR DESCRIPTION
## Summary
- reduce the public training API to one simple path and one fully explicit path
- route the remaining behavior through a single internal runtime-based execution path
- update tests to use the smaller public overload surface

## Why
- keep the training API easier to explain and evolve
- avoid adding more overload combinations as runtime concerns grow

## Related
- Closes #35

## Verification
- [x] `sbt test`
- [x] `sbt scalafmtAll`
- [ ] relevant manual check, if needed

## Out of scope / follow-ups
- adding more runtime knobs
- introducing a public training runtime abstraction