### PR TITLE
feat: add accuracy reporting

### DIFF
--- a/modules/core/src/main/scala/tekhne/model.scala
+++ b/modules/core/src/main/scala/tekhne/model.scala
@@ -95,10 +95,11 @@ final case class TrainingConfig(
   require(epochs > 0, s"epochs must be positive, got $epochs")
   require(batchSize > 0, s"batch size must be positive, got $batchSize")
 
-/** Loss snapshot reported after an epoch completes. */
+/** Metrics snapshot reported after an epoch completes. */
 final case class EpochMetrics(
     epoch: Int,
-    loss: Double
+    loss: Double,
+    accuracy: Option[Double]
 )
 
 private[tekhne] final case class LayerCache(

--- a/modules/core/src/main/scala/tekhne/training.scala
+++ b/modules/core/src/main/scala/tekhne/training.scala
@@ -28,6 +28,24 @@ object Training:
   ): Vector[Vector[(Vec, Vec)]] =
     data.grouped(batchSize).map(_.toVector).toVector
 
+  private def datasetAccuracy(
+      network: Network,
+      data: Vector[(Vec, Vec)]
+  ): Option[Double] =
+    val binaryCompatible = data.forall { case (input, target) =>
+      target.length == 1 && Forward.predict(network, input).length == 1 &&
+      (target.head == 0.0 || target.head == 1.0)
+    }
+
+    if !binaryCompatible then None
+    else
+      val correct = data.count { case (input, target) =>
+        val prediction     = Forward.predict(network, input).head
+        val predictedLabel = if prediction >= 0.5 then 1.0 else 0.0
+        predictedLabel == target.head
+      }
+      Some(correct.toDouble / data.length.toDouble)
+
   private def averageGradients(grads: Vector[Vector[DenseGrad]]): Vector[DenseGrad] =
     require(grads.nonEmpty, "mini-batch gradients must be non-empty")
 
@@ -84,7 +102,13 @@ object Training:
 
         val updated =
           trainEpoch(current, epochData, config.learningRate, config.batchSize, config.loss)
-        runtime.onEpochComplete(EpochMetrics(epoch, datasetLoss(updated, data, config.loss)))
+        runtime.onEpochComplete(
+          EpochMetrics(
+            epoch = epoch,
+            loss = datasetLoss(updated, data, config.loss),
+            accuracy = datasetAccuracy(updated, data)
+          )
+        )
         updated
       }
 

--- a/modules/core/src/test/scala/tekhne/TrainingSuite.scala
+++ b/modules/core/src/test/scala/tekhne/TrainingSuite.scala
@@ -317,6 +317,7 @@ class TrainingSuite extends munit.FunSuite:
 
     assertEquals(observed.map(_.epoch).toVector, Vector(1, 2, 3, 4))
     assert(observed.forall(metrics => metrics.loss.isFinite))
+    assert(observed.forall(_.accuracy.isDefined))
   }
 
   test("reported losses decrease during BCE training") {
@@ -339,6 +340,9 @@ class TrainingSuite extends munit.FunSuite:
 
     assertEquals(observed.length, 10)
     assert(observed.last.loss < observed.head.loss)
+    assert(observed.forall(_.accuracy.isDefined))
+    assert(observed.last.accuracy.get >= observed.head.accuracy.get)
+    assert(observed.last.accuracy.get >= 0.75)
   }
 
   test("metrics callback works with shuffled training when rng is provided") {
@@ -361,6 +365,33 @@ class TrainingSuite extends munit.FunSuite:
 
     assertEquals(observed.map(_.epoch).toVector, Vector(1, 2, 3, 4, 5))
     assert(observed.forall(metrics => metrics.loss.isFinite))
+    assert(observed.forall(_.accuracy.isDefined))
+  }
+
+  test("accuracy is absent when targets are not binary-compatible") {
+    val regressionData = Vector(
+      (Vector(0.0), Vector(0.25)),
+      (Vector(1.0), Vector(0.75))
+    )
+
+    val network = Network.random(
+      layerSizes = Vector(1, 1),
+      activations = Vector(Activation.Sigmoid),
+      rng = new Random(42L)
+    )
+
+    val observed = ArrayBuffer.empty[EpochMetrics]
+
+    Training.train(
+      network,
+      regressionData,
+      TrainingConfig(learningRate = 0.1, epochs = 2),
+      new Random(0L),
+      metrics => observed += metrics
+    )
+
+    assertEquals(observed.length, 2)
+    assert(observed.forall(_.accuracy.isEmpty))
   }
 
   test("linearly separable dataset learns successfully") {

--- a/modules/demo/src/main/scala/AndGateDemo.scala
+++ b/modules/demo/src/main/scala/AndGateDemo.scala
@@ -24,7 +24,12 @@ import scala.util.Random
     TrainingConfig(
       learningRate = 0.2,
       epochs = 20_000
-    )
+    ),
+    new Random(7L),
+    metrics =>
+      if metrics.epoch % 5_000 == 0 then
+        val accuracy = metrics.accuracy.fold("n/a")(value => f"$value%.3f")
+        println(f"epoch ${metrics.epoch}%5d loss=${metrics.loss}%.6f accuracy=$accuracy")
   )
 
   println("AND gate demo")

--- a/modules/demo/src/main/scala/LinearlySeparableDemo.scala
+++ b/modules/demo/src/main/scala/LinearlySeparableDemo.scala
@@ -41,7 +41,8 @@ import scala.util.Random
     new Random(42L),
     metrics =>
       if metrics.epoch % 500 == 0 then
-        println(f"epoch ${metrics.epoch}%4d loss=${metrics.loss}%.6f")
+        val accuracy = metrics.accuracy.fold("n/a")(value => f"$value%.3f")
+        println(f"epoch ${metrics.epoch}%4d loss=${metrics.loss}%.6f accuracy=$accuracy")
   )
 
   val finalLoss = Training.datasetLoss(trained, data, config.loss)

--- a/modules/demo/src/main/scala/Main.scala
+++ b/modules/demo/src/main/scala/Main.scala
@@ -27,7 +27,12 @@ import scala.util.Random
     TrainingConfig(
       learningRate = 0.1,
       epochs = 50_000
-    )
+    ),
+    new Random(42L),
+    metrics =>
+      if metrics.epoch % 10_000 == 0 then
+        val accuracy = metrics.accuracy.fold("n/a")(value => f"$value%.3f")
+        println(f"epoch ${metrics.epoch}%5d loss=${metrics.loss}%.6f accuracy=$accuracy")
   )
 
   val finalLoss = Training.datasetLoss(trained, data)


### PR DESCRIPTION
## Summary
- extend epoch metrics with optional accuracy reporting for binary-compatible runs
- compute accuracy during epoch callbacks without changing training behavior
- update the classification demos to show accuracy alongside loss

## Why
- make training progress easier to interpret than loss alone
- build on the current metrics callback without introducing a heavier metrics system

## Related
- Closes #40

## Verification
- [x] `sbt test`
- [x] `sbt scalafmtAll`
- [x] `sbt \"demo/runMain tekhne.demo.runTekhne\"`
- [x] `sbt \"demo/runMain tekhne.demo.runAndGateDemo\"`
- [x] `sbt \"demo/runMain tekhne.demo.runLinearlySeparableDemo\"`

## Out of scope / follow-ups
- validation accuracy reporting
- richer metrics beyond loss and accuracy