### PR TITLE
fix: harden numerical input validation

### DIFF
--- a/modules/core/src/main/scala/tekhne/backprop.scala
+++ b/modules/core/src/main/scala/tekhne/backprop.scala
@@ -34,6 +34,7 @@ object Backprop:
       forwardPass.output.length == target.length,
       s"target size ${target.length} does not match output size ${forwardPass.output.length}"
     )
+    Loss.requireValidTargets(loss, target)
 
     val outputLayerIndex = network.layers.length - 1
     val lastLayer        = network.layers(outputLayerIndex)

--- a/modules/core/src/main/scala/tekhne/loss.scala
+++ b/modules/core/src/main/scala/tekhne/loss.scala
@@ -6,12 +6,25 @@ import tekhne.Linalg._
 object Loss:
   private val epsilon = 1e-12
 
-  /** Mean squared error averaged across output dimensions. */
-  def mse(output: Vec, target: Vec): Double =
+  private def requireCompatible(output: Vec, target: Vec, operation: String): Unit =
     require(
       output.length == target.length,
-      s"loss dimension mismatch: ${output.length} != ${target.length}"
+      s"$operation dimension mismatch: ${output.length} != ${target.length}"
     )
+    require(output.nonEmpty, s"$operation vectors must be non-empty")
+
+  private[tekhne] def requireValidTargets(loss: LossFunction, target: Vec): Unit =
+    loss match
+      case LossFunction.MeanSquaredError   => ()
+      case LossFunction.BinaryCrossEntropy =>
+        require(
+          target.forall(value => value.isFinite && value >= 0.0 && value <= 1.0),
+          "binary cross-entropy targets must be finite and between 0.0 and 1.0"
+        )
+
+  /** Mean squared error averaged across output dimensions. */
+  def mse(output: Vec, target: Vec): Double =
+    requireCompatible(output, target, "loss")
     output.zip(target).map { case (prediction, expected) =>
       val diff = prediction - expected
       diff * diff
@@ -19,19 +32,14 @@ object Loss:
 
   /** Derivative of mean squared error with respect to the output activations. */
   def mseDerivative(output: Vec, target: Vec): Vec =
-    require(
-      output.length == target.length,
-      s"loss derivative dimension mismatch: ${output.length} != ${target.length}"
-    )
+    requireCompatible(output, target, "loss derivative")
     val scaleFactor = 2.0 / output.length.toDouble
     (output - target) * scaleFactor
 
   /** Binary cross-entropy averaged across output dimensions. */
   def binaryCrossEntropy(output: Vec, target: Vec): Double =
-    require(
-      output.length == target.length,
-      s"loss dimension mismatch: ${output.length} != ${target.length}"
-    )
+    requireCompatible(output, target, "loss")
+    requireValidTargets(LossFunction.BinaryCrossEntropy, target)
     output.zip(target).map { case (prediction, expected) =>
       val clipped = clipProbability(prediction)
       -(expected * math.log(clipped) + (1.0 - expected) * math.log(1.0 - clipped))
@@ -39,10 +47,8 @@ object Loss:
 
   /** Derivative of binary cross-entropy with respect to the output activations. */
   def binaryCrossEntropyDerivative(output: Vec, target: Vec): Vec =
-    require(
-      output.length == target.length,
-      s"loss derivative dimension mismatch: ${output.length} != ${target.length}"
-    )
+    requireCompatible(output, target, "loss derivative")
+    requireValidTargets(LossFunction.BinaryCrossEntropy, target)
     val scaleFactor = 1.0 / output.length.toDouble
     output.zip(target).map { case (prediction, expected) =>
       val clipped = clipProbability(prediction)

--- a/modules/core/src/main/scala/tekhne/model.scala
+++ b/modules/core/src/main/scala/tekhne/model.scala
@@ -91,9 +91,16 @@ final case class TrainingConfig(
     batchSize: Int = 1,
     loss: LossFunction = LossFunction.MeanSquaredError
 ):
-  require(learningRate > 0.0, s"learning rate must be positive, got $learningRate")
+  TrainingConfig.requireValidLearningRate(learningRate)
   require(epochs > 0, s"epochs must be positive, got $epochs")
   require(batchSize > 0, s"batch size must be positive, got $batchSize")
+
+object TrainingConfig:
+  private[tekhne] def requireValidLearningRate(learningRate: Double): Unit =
+    require(
+      learningRate.isFinite && learningRate > 0.0,
+      s"learning rate must be finite and positive, got $learningRate"
+    )
 
 /** Metrics snapshot reported after an epoch completes. */
 final case class EpochMetrics(

--- a/modules/core/src/main/scala/tekhne/training.scala
+++ b/modules/core/src/main/scala/tekhne/training.scala
@@ -63,7 +63,6 @@ object Training:
       loss: LossFunction
   ): Network =
     require(batch.nonEmpty, "mini-batch must be non-empty")
-    require(learningRate > 0.0, s"learning rate must be positive, got $learningRate")
 
     val averagedGrads = averageGradients(batch.map { case (input, target) =>
       Backprop.gradients(network, input, target, loss)
@@ -120,7 +119,7 @@ object Training:
       learningRate: Double,
       loss: LossFunction = LossFunction.MeanSquaredError
   ): Network =
-    require(learningRate > 0.0, s"learning rate must be positive, got $learningRate")
+    TrainingConfig.requireValidLearningRate(learningRate)
     requireLossCompatibility(network, loss)
 
     val grads = Backprop.gradients(network, input, target, loss)
@@ -143,6 +142,8 @@ object Training:
       batchSize: Int = 1,
       loss: LossFunction = LossFunction.MeanSquaredError
   ): Network =
+    require(data.nonEmpty, "training data must be non-empty")
+    TrainingConfig.requireValidLearningRate(learningRate)
     require(batchSize > 0, s"batch size must be positive, got $batchSize")
     requireLossCompatibility(network, loss)
     batchData(data, batchSize).foldLeft(network) { case (current, batch) =>

--- a/modules/core/src/test/scala/tekhne/LossSuite.scala
+++ b/modules/core/src/test/scala/tekhne/LossSuite.scala
@@ -1,6 +1,11 @@
 package tekhne
 
 class LossSuite extends munit.FunSuite:
+  private def assertRejectsEmpty(operation: String)(evaluate: => Unit): Unit =
+    interceptMessage[IllegalArgumentException](
+      s"requirement failed: $operation vectors must be non-empty"
+    )(evaluate)
+
   test("binary cross-entropy returns expected value for simple case") {
     val output = Vector(0.9)
     val target = Vector(1.0)
@@ -24,5 +29,34 @@ class LossSuite extends munit.FunSuite:
       "requirement failed: loss dimension mismatch: 1 != 2"
     ) {
       Loss.binaryCrossEntropy(Vector(0.9), Vector(1.0, 0.0))
+    }
+  }
+
+  test("loss functions reject empty vectors") {
+    assertRejectsEmpty("loss") {
+      Loss.mse(Vector.empty, Vector.empty)
+    }
+    assertRejectsEmpty("loss") {
+      Loss.binaryCrossEntropy(Vector.empty, Vector.empty)
+    }
+    assertRejectsEmpty("loss derivative") {
+      Loss.mseDerivative(Vector.empty, Vector.empty)
+    }
+    assertRejectsEmpty("loss derivative") {
+      Loss.binaryCrossEntropyDerivative(Vector.empty, Vector.empty)
+    }
+  }
+
+  test("binary cross-entropy rejects invalid targets") {
+    Vector(Double.NaN, Double.PositiveInfinity, -0.1, 1.1).foreach { invalidTarget =>
+      val expectedMessage =
+        "requirement failed: binary cross-entropy targets must be finite and between 0.0 and 1.0"
+
+      interceptMessage[IllegalArgumentException](expectedMessage) {
+        Loss.binaryCrossEntropy(Vector(0.5), Vector(invalidTarget))
+      }
+      interceptMessage[IllegalArgumentException](expectedMessage) {
+        Loss.binaryCrossEntropyDerivative(Vector(0.5), Vector(invalidTarget))
+      }
     }
   }

--- a/modules/core/src/test/scala/tekhne/ValidationSuite.scala
+++ b/modules/core/src/test/scala/tekhne/ValidationSuite.scala
@@ -1,6 +1,18 @@
 package tekhne
 
 class ValidationSuite extends munit.FunSuite:
+  private val sigmoidNetwork = Network(
+    Vector(
+      Dense(
+        weights = Vector(Vector(0.1)),
+        bias = Vector(0.0),
+        activation = Activation.Sigmoid
+      )
+    )
+  )
+
+  private val singleExample = Vector((Vector(1.0), Vector(1.0)))
+
   test("dense rejects bias size mismatch") {
     interceptMessage[IllegalArgumentException](
       "requirement failed: bias size 1 must match output size 2"
@@ -41,11 +53,19 @@ class ValidationSuite extends munit.FunSuite:
     }
   }
 
-  test("training config rejects non-positive values") {
+  test("training config rejects invalid values") {
     interceptMessage[IllegalArgumentException](
-      "requirement failed: learning rate must be positive, got 0.0"
+      "requirement failed: learning rate must be finite and positive, got 0.0"
     ) {
       TrainingConfig(learningRate = 0.0, epochs = 10)
+    }
+
+    Vector(Double.NaN, Double.PositiveInfinity, Double.NegativeInfinity).foreach { learningRate =>
+      interceptMessage[IllegalArgumentException](
+        s"requirement failed: learning rate must be finite and positive, got $learningRate"
+      ) {
+        TrainingConfig(learningRate = learningRate, epochs = 10)
+      }
     }
 
     interceptMessage[IllegalArgumentException](
@@ -58,6 +78,57 @@ class ValidationSuite extends munit.FunSuite:
       "requirement failed: batch size must be positive, got 0"
     ) {
       TrainingConfig(learningRate = 0.1, epochs = 10, batchSize = 0)
+    }
+  }
+
+  test("training operations reject non-finite learning rates") {
+    Vector(Double.NaN, Double.PositiveInfinity).foreach { learningRate =>
+      val expectedMessage =
+        s"requirement failed: learning rate must be finite and positive, got $learningRate"
+
+      interceptMessage[IllegalArgumentException](expectedMessage) {
+        Training.step(
+          sigmoidNetwork,
+          singleExample.head._1,
+          singleExample.head._2,
+          learningRate
+        )
+      }
+      interceptMessage[IllegalArgumentException](expectedMessage) {
+        Training.trainEpoch(sigmoidNetwork, singleExample, learningRate)
+      }
+    }
+  }
+
+  test("training operations reject empty datasets consistently") {
+    val expectedMessage = "requirement failed: training data must be non-empty"
+
+    interceptMessage[IllegalArgumentException](expectedMessage) {
+      Training.train(
+        sigmoidNetwork,
+        Vector.empty,
+        TrainingConfig(learningRate = 0.1, epochs = 1)
+      )
+    }
+    interceptMessage[IllegalArgumentException](expectedMessage) {
+      Training.trainEpoch(sigmoidNetwork, Vector.empty, learningRate = 0.1)
+    }
+    interceptMessage[IllegalArgumentException](expectedMessage) {
+      Training.datasetLoss(sigmoidNetwork, Vector.empty)
+    }
+  }
+
+  test("binary cross-entropy training rejects invalid targets") {
+    interceptMessage[IllegalArgumentException](
+      "requirement failed: binary cross-entropy targets must be finite and between 0.0 and 1.0"
+    ) {
+      Training.step(
+        sigmoidNetwork,
+        input = Vector(1.0),
+        target = Vector(1.1),
+        learningRate = 0.1,
+        loss = LossFunction.BinaryCrossEntropy
+      )
     }
   }
 


### PR DESCRIPTION
## Summary
- reject non-finite learning rates
- reject empty loss vectors and datasets
- validate BCE targets across loss and training paths

## Related
- Closes #50

## Verification
- [x] `sbt core/test`
- [x] `sbt scalafmtCheckAll`
- [x] `sbt "scalafixAll --check"`